### PR TITLE
处理在resolve之后，id变为绝对路径的问题

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,8 +140,11 @@ async function build({
         }
       }
       
-      if (r && !/node_modules/.test(s)){
-        return false;
+      if (r){
+        const pathNames = s.split(path.sep);
+        if (!pathNames.includes('node_modules')){
+          return false;
+        }
       }
       
       return true;

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ async function build({
 
     preserveModules,
 
-    external: external || function (s) {
+    external: external || function (s, p, r) {
       const isLocal = (s.startsWith('/') || s.startsWith('./') || s.startsWith('../'));
       if (isLocal) {
         return false;
@@ -139,6 +139,11 @@ async function build({
           return false;
         }
       }
+      
+      if (r && !/node_modules/.test(s)){
+        return false;
+      }
+      
       return true;
     },
     plugins,


### PR DESCRIPTION
在windows上会对引用对路径进行转换，这个时候获得的是绝对路径，不能以startwith(./)这样的方式处理